### PR TITLE
Ensure sourcemaps load correctly

### DIFF
--- a/src/main/java/com/google/gwt/site/webapp/GWTProject.gwt.xml
+++ b/src/main/java/com/google/gwt/site/webapp/GWTProject.gwt.xml
@@ -12,7 +12,7 @@
     <set-property name="compiler.useSourceMaps" value="true"/>
     <!-- change to localhost for development -->
     <set-configuration-property name="includeSourceMapUrl" 
-    	value="http://www.gwtproject.org/src/__HASH___sourceMap__FRAGMENT__.json"/>
+    	value="https://www.gwtproject.org/src/__HASH___sourceMap__FRAGMENT__.json"/>
 
     <set-configuration-property name="installCode" value="false"/>
     <!-- remove after fix to issue 8630 lands -->


### PR DESCRIPTION
Firefox doesn't seem to follow redirects to load sourcemaps, this ensures that they work properly when deployed to gwtproject.org.