### PR TITLE
Bump versions of actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -22,7 +22,7 @@ jobs:
         # Fixes issue where artifact zip contains top level directory due to wildcard expansion
         run: mv target/gwt-site-webapp-*/ target/gwt-site-webapp
       - name: Upload the generated JS
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'gwt-site-webapp'
           path: target/gwt-site-webapp/


### PR DESCRIPTION
Specifically, this gets us to a non-deprecated upload-artifact tag.